### PR TITLE
Update to 2.3.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.0
+current_version = 2.2.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.1
+current_version = 2.2.2
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.3.0
+current_version = 2.3.1
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.2.2
+current_version = 2.3.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.3
+current_version = 2.2.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ install:
 script:
   - tox -e $TOXENV
 after_success:
-  - test $TRAVIS_BRANCH = "master" &&
+  - test $TRAVIS_BRANCH = "main" &&
     test $TOXENV = "py36" &&
     coverage xml -i
-  - test $TRAVIS_BRANCH = "master" &&
+  - test $TRAVIS_BRANCH = "main" &&
     test $TOXENV = "py36" &&
     codecov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Your commits should be pushed to the forked repository. To verify this type
 git remote -v
 ```
 
-and ensure the remotes point to your GitHub. Don't work on the master branch!
+and ensure the remotes point to your GitHub. Don't work on the main branch!
 
 1. Commit changes to local repository:
 
@@ -149,6 +149,6 @@ _Note: You might want to set a reference to the main repository to fetch/merge f
 git remote add upstream https://github.com/nteract/papermill
 ```
 
-It's possible you will have conflicts between your repository and master. Here, `master` is meant to be synchronized with the ```upstream``` repository.  GitHub has some good [documentation](https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/) on merging pull requests from the command line.
+It's possible you will have conflicts between your repository and main. Here, `main` is meant to be synchronized with the ```upstream``` repository.  GitHub has some good [documentation](https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/) on merging pull requests from the command line.
 
 Happy hacking on Papermill!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ We encourage friendly discussions and respect for all. There are no exceptions.
 
 All contributions are equally important. Documentation, answering questions, and fixing bugs are equally as valuable as adding new features.
 
-Please read our entire code of conduct [here](https://github.com/nteract/nteract/blob/master/CODE_OF_CONDUCT.md). Also, check out the for the [Python](https://github.com/nteract/nteract/blob/master/CODE_OF_CONDUCT.md) code of conduct.
+Please read our entire [Code of Conduct](https://github.com/nteract/nteract/blob/master/CODE_OF_CONDUCT.md).
 
 ## Setting up Your Development Environment
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 =======================================================================================================================================================================
 
 <!---(binder links generated at https://mybinder.readthedocs.io/en/latest/howto/badges.html and compressed at https://tinyurl.com) -->
-[![Travis Build Status](https://travis-ci.org/nteract/papermill.svg?branch=master)](https://travis-ci.org/nteract/papermill)
-[![Azure Build Status](https://dev.azure.com/nteract/nteract/_apis/build/status/nteract.papermill?branchName=master)](https://dev.azure.com/nteract/nteract/_build/latest?definitionId=5&branchName=master)
-[![image](https://codecov.io/github/nteract/papermill/coverage.svg?branch=master)](https://codecov.io/github/nteract/papermill?branch=master)
+[![Travis Build Status](https://travis-ci.org/nteract/papermill.svg?branch=main)](https://travis-ci.org/nteract/papermill)
+[![Azure Build Status](https://dev.azure.com/nteract/nteract/_apis/build/status/nteract.papermill?branchName=main)](https://dev.azure.com/nteract/nteract/_build/latest?definitionId=5&branchName=main)
+[![image](https://codecov.io/github/nteract/papermill/coverage.svg?branch=main)](https://codecov.io/github/nteract/papermill?branch=main)
 [![Documentation Status](https://readthedocs.org/projects/papermill/badge/?version=latest)](http://papermill.readthedocs.io/en/latest/?badge=latest)
-[![badge](https://tinyurl.com/ybwovtw2)](https://mybinder.org/v2/gh/nteract/papermill/master?filepath=binder%2Fprocess_highlight_dates.ipynb)
-[![badge](https://tinyurl.com/y7uz2eh9)](https://mybinder.org/v2/gh/nteract/papermill/master?)
+[![badge](https://tinyurl.com/ybwovtw2)](https://mybinder.org/v2/gh/nteract/papermill/main?filepath=binder%2Fprocess_highlight_dates.ipynb)
+[![badge](https://tinyurl.com/y7uz2eh9)](https://mybinder.org/v2/gh/nteract/papermill/main?)
 [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
 [![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/downloads/release/python-370/)
 [![Python 3.8](https://img.shields.io/badge/python-3.8-blue.svg)](https://www.python.org/downloads/release/python-380/)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 trigger:
-  - master
+  - main
 
 # Set variables once
 variables:

--- a/binder/cli-simple/cli_example.ipynb
+++ b/binder/cli-simple/cli_example.ipynb
@@ -47,7 +47,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "parametesr"
+     "parameters"
     ]
    },
    "outputs": [],

--- a/binder/cli-simple/simple_output.ipynb
+++ b/binder/cli-simple/simple_output.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "metadata": {
     "papermill": {
-     "duration": 0.019085,
-     "end_time": "2020-06-15T00:38:19.879972",
+     "duration": 0.00964,
+     "end_time": "2020-08-17T19:57:24.239226",
      "exception": false,
-     "start_time": "2020-06-15T00:38:19.860887",
+     "start_time": "2020-08-17T19:57:24.229586",
      "status": "completed"
     },
     "tags": []
@@ -21,16 +21,16 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-06-15T00:38:19.895422Z",
-     "iopub.status.busy": "2020-06-15T00:38:19.894896Z",
-     "iopub.status.idle": "2020-06-15T00:38:19.896926Z",
-     "shell.execute_reply": "2020-06-15T00:38:19.897449Z"
+     "iopub.execute_input": "2020-08-17T19:57:24.263404Z",
+     "iopub.status.busy": "2020-08-17T19:57:24.262659Z",
+     "iopub.status.idle": "2020-08-17T19:57:24.265395Z",
+     "shell.execute_reply": "2020-08-17T19:57:24.264689Z"
     },
     "papermill": {
-     "duration": 0.009661,
-     "end_time": "2020-06-15T00:38:19.897597",
+     "duration": 0.012719,
+     "end_time": "2020-08-17T19:57:24.265567",
      "exception": false,
-     "start_time": "2020-06-15T00:38:19.887936",
+     "start_time": "2020-08-17T19:57:24.252848",
      "status": "completed"
     },
     "tags": [
@@ -47,16 +47,16 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-06-15T00:38:19.905246Z",
-     "iopub.status.busy": "2020-06-15T00:38:19.904797Z",
-     "iopub.status.idle": "2020-06-15T00:38:19.906324Z",
-     "shell.execute_reply": "2020-06-15T00:38:19.906762Z"
+     "iopub.execute_input": "2020-08-17T19:57:24.274405Z",
+     "iopub.status.busy": "2020-08-17T19:57:24.273934Z",
+     "iopub.status.idle": "2020-08-17T19:57:24.276194Z",
+     "shell.execute_reply": "2020-08-17T19:57:24.275695Z"
     },
     "papermill": {
-     "duration": 0.006814,
-     "end_time": "2020-06-15T00:38:19.906867",
+     "duration": 0.007713,
+     "end_time": "2020-08-17T19:57:24.276300",
      "exception": false,
-     "start_time": "2020-06-15T00:38:19.900053",
+     "start_time": "2020-08-17T19:57:24.268587",
      "status": "completed"
     },
     "tags": [
@@ -74,16 +74,16 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2020-06-15T00:38:19.914520Z",
-     "iopub.status.busy": "2020-06-15T00:38:19.914053Z",
-     "iopub.status.idle": "2020-06-15T00:38:19.916372Z",
-     "shell.execute_reply": "2020-06-15T00:38:19.915909Z"
+     "iopub.execute_input": "2020-08-17T19:57:24.283119Z",
+     "iopub.status.busy": "2020-08-17T19:57:24.282711Z",
+     "iopub.status.idle": "2020-08-17T19:57:24.284846Z",
+     "shell.execute_reply": "2020-08-17T19:57:24.284482Z"
     },
     "papermill": {
-     "duration": 0.00722,
-     "end_time": "2020-06-15T00:38:19.916452",
+     "duration": 0.006366,
+     "end_time": "2020-08-17T19:57:24.284929",
      "exception": false,
-     "start_time": "2020-06-15T00:38:19.909232",
+     "start_time": "2020-08-17T19:57:24.278563",
      "status": "completed"
     },
     "tags": []
@@ -123,8 +123,8 @@
    "version": "3.8.2"
   },
   "papermill": {
-   "duration": 0.823709,
-   "end_time": "2020-06-15T00:38:20.126604",
+   "duration": 0.727728,
+   "end_time": "2020-08-17T19:57:24.494284",
    "environment_variables": {},
    "exception": null,
    "input_path": "binder/cli-simple/simple_input.ipynb",
@@ -132,8 +132,8 @@
    "parameters": {
     "msg": "Hello"
    },
-   "start_time": "2020-06-15T00:38:19.302895",
-   "version": "2.1.1"
+   "start_time": "2020-08-17T19:57:23.766556",
+   "version": "2.1.3"
   }
  },
  "nbformat": 4,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,12 +1,21 @@
 # Change Log
 
+## 2.3.0
+
+- Notebooks that are loaded with papermill now upgrade the document to the latest spec version (to support cell-id assignments).
+- Empty yaml files are now accepted as parameter files
+- Binder typo fix for example notebook
+- Entry point documentation improvements
+- Code of Conduct documentation link cleanup
+- Tox change for local doc builds
+
 ## 2.2.1
 
-* Allow `pathlib.Path`s in `execute_notebook` and `inspect_notebook`
+- Allow `pathlib.Path`s in `execute_notebook` and `inspect_notebook`
 
 ## 2.2.0
 
-* Provide help for Python notebooks by inspecting the `parameters` cell, via `--help-notebook`
+- Provide help for Python notebooks by inspecting the `parameters` cell, via `--help-notebook`
 - Support added for parameterizing Powershell kernels
 
 ## 2.1.3

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,9 +1,12 @@
 # Change Log
 
+## 2.2.1
+
+* Allow `pathlib.Path`s in `execute_notebook` and `inspect_notebook`
+
 ## 2.2.0
 
-* Provide help for notebooks by inspecting the `parameters` cell, via `--help-notebook`
-* Allow `pathlib.Path`s in `execute_notebook` and `inspect_notebook`
+* Provide help for Python notebooks by inspecting the `parameters` cell, via `--help-notebook`
 - Support added for parameterizing Powershell kernels
 
 ## 2.1.3

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.3.1
+
+- Added minimum version pin for nbformat
+
 ## 2.3.0
 
 - Notebooks that are loaded with papermill now upgrade the document to the latest spec version (to support cell-id assignments).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.2.0
+
+* Provide help for notebooks by inspecting the `parameters` cell, via `--help-notebook`
+* Allow `pathlib.Path`s in `execute_notebook` and `inspect_notebook`
+- Support added for parameterizing Powershell kernels
+
 ## 2.1.3
 
 - Removed jupyter_client dependency in requirements to avoid confusing pip on the actual version requirements.

--- a/docs/extending-developing.rst
+++ b/docs/extending-developing.rst
@@ -12,5 +12,5 @@ Development of papermill happens on github, and a
 `code of conduct`_ there. Please read both documents before beginning!
 
 
-.. _`detailed guide to contributing`: https://github.com/nteract/papermill/blob/master/CONTRIBUTING.md
+.. _`detailed guide to contributing`: https://github.com/nteract/papermill/blob/main/CONTRIBUTING.md
 .. _`code of conduct`: https://github.com/nteract/nteract/blob/master/CODE_OF_CONDUCT.md

--- a/docs/extending-entry-points.rst
+++ b/docs/extending-entry-points.rst
@@ -274,7 +274,7 @@ file, you should specify:
         packages=find_packages("./src"),
         package_dir={"": "src"},
         install_requires=["papermill", "nbformat"],
-        entry_points={"papermill.engine": ["timer_engine=papermill_timing:TimingEngine"]},
+        entry_points={"papermill.engine": ["timer_engine=papermill_timing:CustomEngine"]},
     )
 
 This allows users to specify the engine from ``papermill_timing`` by passing the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,16 @@
 Welcome to papermill
 ====================
 
-.. image:: https://travis-ci.org/nteract/papermill.svg?branch=master
+.. image:: https://travis-ci.org/nteract/papermill.svg?branch=main
    :target: https://travis-ci.org/nteract/papermill
-.. image:: https://codecov.io/github/nteract/papermill/coverage.svg?branch=master
-   :target: https://codecov.io/github/nteract/papermill?branch=master
+.. image:: https://codecov.io/github/nteract/papermill/coverage.svg?branch=main
+   :target: https://codecov.io/github/nteract/papermill?branch=main
 .. image:: https://readthedocs.org/projects/papermill/badge/?version=latest
    :target: http://papermill.readthedocs.io/en/latest/?badge=latest
 .. image:: https://tinyurl.com/ybwovtw2
-   :target: https://mybinder.org/v2/gh/nteract/papermill/master?filepath=binder%2Fprocess_highlight_dates.ipynb
+   :target: https://mybinder.org/v2/gh/nteract/papermill/main?filepath=binder%2Fprocess_highlight_dates.ipynb
 .. image:: https://tinyurl.com/y7uz2eh9
-   :target: https://mybinder.org/v2/gh/nteract/papermill/master?filepath=binder%2Fcli-simple%2Fcli_example.ipynb
+   :target: https://mybinder.org/v2/gh/nteract/papermill/main?filepath=binder%2Fcli-simple%2Fcli_example.ipynb
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/ambv/black
 

--- a/docs/usage-cli.rst
+++ b/docs/usage-cli.rst
@@ -6,7 +6,7 @@ options:
 
 .. code-block:: bash
 
-    Usage: papermill [OPTIONS] NOTEBOOK_PATH OUTPUT_PATH
+    Usage: papermill [OPTIONS] NOTEBOOK_PATH [OUTPUT_PATH]
 
       This utility executes a single notebook in a subprocess.
 
@@ -24,6 +24,9 @@ options:
       stdin and write it out to stdout.
 
     Options:
+      --help-notebook                 Display parameters information for the given
+                                      notebook path.
+
       -p, --parameters TEXT...        Parameters to pass to the parameters cell.
       -r, --parameters_raw TEXT...    Parameters to be read as raw string.
       -f, --parameters_file TEXT      Path to YAML file containing parameters.
@@ -32,34 +35,47 @@ options:
       --inject-input-path             Insert the path of the input notebook as
                                       PAPERMILL_INPUT_PATH as a notebook
                                       parameter.
+
       --inject-output-path            Insert the path of the output notebook as
                                       PAPERMILL_OUTPUT_PATH as a notebook
                                       parameter.
+
       --inject-paths                  Insert the paths of input/output notebooks
                                       as
                                       PAPERMILL_INPUT_PATH/PAPERMILL_OUTPUT_PATH
                                       as notebook parameters.
+
       --engine TEXT                   The execution engine name to use in
                                       evaluating the notebook.
+
       --request-save-on-cell-execute / --no-request-save-on-cell-execute
                                       Request save notebook after each cell
                                       execution
+
+      --autosave-cell-every INTEGER   How often in seconds to autosave the
+                                      notebook during long cell executions (0 to
+                                      disable)
+
       --prepare-only / --prepare-execute
                                       Flag for outputting the notebook without
                                       execution, but with parameters applied.
+
       -k, --kernel TEXT               Name of kernel to run.
       --cwd TEXT                      Working directory to run notebook in.
       --progress-bar / --no-progress-bar
                                       Flag for turning on the progress bar.
       --log-output / --no-log-output  Flag for writing notebook output to the
                                       configured logger.
+
       --stdout-file FILENAME          File to write notebook stdout output to.
       --stderr-file FILENAME          File to write notebook stderr output to.
       --log-level [NOTSET|DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                       Set log level
-      --start-timeout INTEGER         Time in seconds to wait for kernel to start.
+      --start-timeout, --start_timeout INTEGER
+                                      Time in seconds to wait for kernel to start.
       --execution-timeout INTEGER     Time in seconds to wait for each cell before
                                       failing execution (default: forever)
+
       --report-mode / --no-report-mode
                                       Flag for hiding input.
       --version                       Flag for displaying the version.

--- a/docs/usage-inspect.rst
+++ b/docs/usage-inspect.rst
@@ -1,0 +1,56 @@
+Inspect
+=======
+
+The two ways to inspect the notebook to discover its parameters are: (1) through the
+Python API and (2) through the command line interface.
+
+Execute via the Python API
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `inspect_notebook` function can be called to inspect a notebook:
+
+.. code-block:: python
+
+   inspect_notebook(<notebook path>)
+
+
+
+.. code-block:: python
+
+   import papermill as pm
+
+   pm.inspect_notebook('path/to/input.ipynb')
+
+.. note::
+    If your path is parametrized, you can pass those parameters in a dictionary
+    as second parameter:
+
+    ``inspect_notebook('path/to/input_{month}.ipynb', parameters={month='Feb'})``
+
+Inspect via CLI
+~~~~~~~~~~~~~~~
+
+To inspect a notebook using the CLI, enter the ``papermill --help-notebook`` command in the
+terminal with the notebook and optionally path parameters.
+
+.. seealso::
+
+    :doc:`CLI reference <./usage-cli>`
+
+Inspect a notebook
+^^^^^^^^^^^^^^^^^^
+
+Here's an example of a local notebook being inspected and an output example:
+
+.. code-block:: bash
+
+    papermill --help-notebook ./papermill/tests/notebooks/complex_parameters.ipynb
+
+    Usage: papermill [OPTIONS] NOTEBOOK_PATH [OUTPUT_PATH]
+
+    Parameters inferred for notebook './papermill/tests/notebooks/complex_parameters.ipynb':
+    msg: Unknown type (default None)
+    a: float (default 2.25)         Variable a
+    b: List[str] (default ['Hello','World'])
+                                    Nice list
+    c: NoneType (default None)

--- a/docs/usage-workflow.rst
+++ b/docs/usage-workflow.rst
@@ -21,6 +21,7 @@ a collection of notebooks.
    :maxdepth: 2
 
    usage-parameterize
+   usage-inspect
    usage-execute
    usage-store
 

--- a/docs/usage-workflow.rst
+++ b/docs/usage-workflow.rst
@@ -6,7 +6,7 @@ For an interactive example that demonstrates the usage of papermill, click the B
 below:
 
 .. image:: https://mybinder.org/badge.svg
-   :target: https://mybinder.org/v2/gh/nteract/papermill/master?filepath=binder%2Fprocess_highlight_dates.ipynb
+   :target: https://mybinder.org/v2/gh/nteract/papermill/main?filepath=binder%2Fprocess_highlight_dates.ipynb
    :alt: launch binder
 
 Using papermill

--- a/papermill/__init__.py
+++ b/papermill/__init__.py
@@ -2,3 +2,4 @@ from .version import version as __version__
 
 from .exceptions import PapermillException, PapermillExecutionError
 from .execute import execute_notebook
+from .inspection import inspect_notebook

--- a/papermill/cli.py
+++ b/papermill/cli.py
@@ -223,11 +223,11 @@ def papermill(
     if inject_output_path or inject_paths:
         parameters_final['PAPERMILL_OUTPUT_PATH'] = output_path
     for params in parameters_base64 or []:
-        parameters_final.update(yaml.load(base64.b64decode(params), Loader=NoDatesSafeLoader))
+        parameters_final.update(yaml.load(base64.b64decode(params), Loader=NoDatesSafeLoader) or {})
     for files in parameters_file or []:
-        parameters_final.update(read_yaml_file(files))
+        parameters_final.update(read_yaml_file(files) or {})
     for params in parameters_yaml or []:
-        parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader))
+        parameters_final.update(yaml.load(params, Loader=NoDatesSafeLoader) or {})
     for name, value in parameters or []:
         parameters_final[name] = _resolve_type(value)
     for name, value in parameters_raw or []:

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -5,10 +5,10 @@ import nbformat
 
 from .log import logger
 from .exceptions import PapermillExecutionError
-from .iorw import load_notebook_node, write_ipynb, get_pretty_path, local_file_io_cwd
+from .iorw import get_pretty_path, local_file_io_cwd, load_notebook_node, write_ipynb
 from .engines import papermill_engines
 from .utils import chdir
-from .parameterize import parameterize_notebook, parameterize_path, add_builtin_parameters
+from .parameterize import add_builtin_parameters, parameterize_notebook, parameterize_path
 
 
 def execute_notebook(

--- a/papermill/execute.py
+++ b/papermill/execute.py
@@ -2,6 +2,7 @@
 
 import copy
 import nbformat
+from pathlib import Path
 
 from .log import logger
 from .exceptions import PapermillExecutionError
@@ -32,9 +33,9 @@ def execute_notebook(
 
     Parameters
     ----------
-    input_path : str
+    input_path : str or Path
         Path to input notebook
-    output_path : str
+    output_path : str or Path
         Path to save executed notebook
     parameters : dict, optional
         Arbitrary keyword arguments to pass to the notebook parameters
@@ -56,7 +57,7 @@ def execute_notebook(
         Duration in seconds to wait for kernel start-up
     report_mode : bool, optional
         Flag for whether or not to hide input.
-    cwd : str, optional
+    cwd : str or Path, optional
         Working directory to use when executing the notebook
     **kwargs
         Arbitrary keyword arguments to pass to the notebook engine
@@ -66,6 +67,13 @@ def execute_notebook(
     nb : NotebookNode
        Executed notebook object
     """
+    if isinstance(input_path, Path):
+        input_path = str(input_path)
+    if isinstance(output_path, Path):
+        output_path = str(output_path)
+    if isinstance(cwd, Path):
+        cwd = str(cwd)
+
     path_parameters = add_builtin_parameters(parameters)
     input_path = parameterize_path(input_path, path_parameters)
     output_path = parameterize_path(output_path, path_parameters)

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Deduce parameters of a notebook from the parameters cell."""
+import click
+
+from .iorw import get_pretty_path, load_notebook_node, local_file_io_cwd
+from .log import logger
+from .parameterize import add_builtin_parameters, parameterize_path
+from .translators import papermill_translators
+from .utils import any_tagged_cell, find_first_tagged_cell_index
+
+
+def _open_notebook(notebook_path, parameters):
+    path_parameters = add_builtin_parameters(parameters)
+    input_path = parameterize_path(notebook_path, path_parameters)
+    logger.info("Input Notebook:  %s" % get_pretty_path(input_path))
+
+    with local_file_io_cwd():
+        return load_notebook_node(input_path)
+
+
+def _infer_parameters(nb):
+    """Infer the notebook parameters.
+
+    Parameters
+    ----------
+    nb : nbformat.NotebookNode
+        Notebook
+
+    Returns
+    -------
+    List[Parameter]
+       List of parameters (name, inferred_type_name, default, help)
+    """
+    params = []
+
+    parameter_cell_idx = find_first_tagged_cell_index(nb, "parameters")
+    if parameter_cell_idx < 0:
+        return params
+    parameter_cell = nb.cells[parameter_cell_idx]
+    kernel_name = nb.metadata.kernelspec.name
+    language = nb.metadata.kernelspec.language
+
+    translator = papermill_translators.find_translator(kernel_name, language)
+    try:
+        params = translator.inspect(parameter_cell)
+    except NotImplementedError:
+        logger.warning(
+            "Translator for '{}' language does not support parameter introspection.".format(
+                language
+            )
+        )
+
+    return params
+
+
+def display_notebook_help(ctx, notebook_path, parameters):
+    """Display help on notebook parameters.
+
+    Parameters
+    ----------
+    ctx : click.Context
+        Click context
+    notebook_path : str
+        Path to the notebook to be inspected
+    """
+    nb = _open_notebook(notebook_path, parameters)
+    click.echo(ctx.command.get_usage(ctx))
+    pretty_path = get_pretty_path(notebook_path)
+    click.echo("\nParameters inferred for notebook '{}':".format(pretty_path))
+
+    if not any_tagged_cell(nb, "parameters"):
+        click.echo("\n  No cell tagged 'parameters'")
+        return 1
+
+    params = _infer_parameters(nb)
+    if params:
+        for param in params:
+            p = param._asdict()
+            type_repr = p["inferred_type_name"]
+            if type_repr == "None":
+                type_repr = "Unknown type"
+
+            definition = "  {}: {} (default {})".format(p["name"], type_repr, p["default"])
+            if len(definition) > 30:
+                if len(p["help"]):
+                    param_help = "".join((definition, "\n", 34 * " ", p["help"]))
+                else:
+                    param_help = definition
+            else:
+                param_help = "{:<34}{}".format(definition, p["help"])
+            click.echo(param_help)
+    else:
+        click.echo(
+            "\n  Can't infer anything about this notebook's parameters. "
+            "It may not have any parameter defined."
+        )
+
+    return 0
+
+
+def inspect_notebook(notebook_path, parameters=None):
+    """Return the inferred notebook parameters.
+
+    Parameters
+    ----------
+    notebook_path : str
+        Path to notebook
+    parameters : dict, optional
+        Arbitrary keyword arguments to pass to the notebook parameters
+
+    Returns
+    -------
+    Dict[str, Parameter]
+       Mapping of (parameter name, {name, inferred_type_name, default, help})
+    """
+    nb = _open_notebook(notebook_path, parameters)
+
+    params = _infer_parameters(nb)
+    return {p.name: p._asdict() for p in params}

--- a/papermill/inspection.py
+++ b/papermill/inspection.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Deduce parameters of a notebook from the parameters cell."""
 import click
+from pathlib import Path
 
 from .iorw import get_pretty_path, load_notebook_node, local_file_io_cwd
 from .log import logger
@@ -103,7 +104,7 @@ def inspect_notebook(notebook_path, parameters=None):
 
     Parameters
     ----------
-    notebook_path : str
+    notebook_path : str or Path
         Path to notebook
     parameters : dict, optional
         Arbitrary keyword arguments to pass to the notebook parameters
@@ -113,6 +114,9 @@ def inspect_notebook(notebook_path, parameters=None):
     Dict[str, Parameter]
        Mapping of (parameter name, {name, inferred_type_name, default, help})
     """
+    if isinstance(notebook_path, Path):
+        notebook_path = str(notebook_path)
+
     nb = _open_notebook(notebook_path, parameters)
 
     params = _infer_parameters(nb)

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -16,14 +16,14 @@ from contextlib import contextmanager
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from . import __version__
-from .log import logger
-from .utils import chdir
 from .exceptions import (
     PapermillException,
     PapermillRateLimitException,
     missing_dependency_generator,
     missing_environment_variable_generator,
 )
+from .log import logger
+from .utils import chdir
 
 try:
     from .s3 import S3
@@ -411,6 +411,7 @@ def load_notebook_node(notebook_path):
 
     if not hasattr(nb.metadata, 'papermill'):
         nb.metadata['papermill'] = {
+            'default_parameters': dict(),
             'parameters': dict(),
             'environment_variables': dict(),
             'version': __version__,
@@ -422,6 +423,7 @@ def load_notebook_node(notebook_path):
 
         if not hasattr(cell.metadata, 'papermill'):
             cell.metadata['papermill'] = dict()
+
     return nb
 
 

--- a/papermill/iorw.py
+++ b/papermill/iorw.py
@@ -408,6 +408,9 @@ def load_notebook_node(notebook_path):
 
     """
     nb = nbformat.reads(papermill_io.read(notebook_path), as_version=4)
+    nb_upgraded = nbformat.v4.upgrade(nb)
+    if nb_upgraded is not None:
+        nb = nb_upgraded
 
     if not hasattr(nb.metadata, 'papermill'):
         nb.metadata['papermill'] = {

--- a/papermill/models.py
+++ b/papermill/models.py
@@ -1,0 +1,9 @@
+"""Models used by papermill."""
+from collections import namedtuple
+
+Parameter = namedtuple('Parameter', [
+    'name',
+    'inferred_type_name',  # string of type
+    'default',  # string representing the default value
+    'help',
+])

--- a/papermill/parameterize.py
+++ b/papermill/parameterize.py
@@ -1,10 +1,11 @@
 import copy
 import nbformat
 
-from .translators import translate_parameters
 from .log import logger
 from .exceptions import PapermillMissingParameterException
 from .iorw import read_yaml_file
+from .translators import translate_parameters
+from .utils import find_first_tagged_cell_index
 
 from uuid import uuid4
 from datetime import datetime
@@ -85,8 +86,8 @@ def parameterize_notebook(nb, parameters, report_mode=False, comment='Parameters
         newcell.metadata['jupyter'] = newcell.get('jupyter', {})
         newcell.metadata['jupyter']['source_hidden'] = True
 
-    param_cell_index = _find_first_tagged_cell_index(nb, 'parameters')
-    injected_cell_index = _find_first_tagged_cell_index(nb, 'injected-parameters')
+    param_cell_index = find_first_tagged_cell_index(nb, 'parameters')
+    injected_cell_index = find_first_tagged_cell_index(nb, 'injected-parameters')
     if injected_cell_index >= 0:
         # Replace the injected cell with a new version
         before = nb.cells[:injected_cell_index]
@@ -105,13 +106,3 @@ def parameterize_notebook(nb, parameters, report_mode=False, comment='Parameters
     nb.metadata.papermill['parameters'] = parameters
 
     return nb
-
-
-def _find_first_tagged_cell_index(nb, tag):
-    parameters_indices = []
-    for idx, cell in enumerate(nb.cells):
-        if tag in cell.metadata.tags:
-            parameters_indices.append(idx)
-    if not parameters_indices:
-        return -1
-    return parameters_indices[0]

--- a/papermill/tests/notebooks/complex_parameters.ipynb
+++ b/papermill/tests/notebooks/complex_parameters.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "msg = None\n",
+    "a: float = 2.25 # Variable a\n",
+    "b = [\n",
+    "    'Hello', # First element\n",
+    "# Dummy comment\n",
+    "    'World'\n",
+    "] # type: List[str] Nice list\n",
+    "\n",
+    "# Interesting c variable\n",
+    "c: \"NoneType\" = None\n",
+    "# Not introspectable line\n",
+    "d = a == 3\n",
+    "# Broken name definition\n",
+    "= 2"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/papermill/tests/notebooks/nb_version_4.4.ipynb
+++ b/papermill/tests/notebooks/nb_version_4.4.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "var = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(var)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/papermill/tests/notebooks/notimplemented_translator.ipynb
+++ b/papermill/tests/notebooks/notimplemented_translator.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "msg = None"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "r",
+   "language": "R",
+   "name": "r"
+  },
+  "language_info": {
+   "name": ""
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/papermill/tests/notebooks/systemexit.ipynb
+++ b/papermill/tests/notebooks/systemexit.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raise SystemExit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Cell should not execute.\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -134,8 +134,9 @@ class TestCLI(unittest.TestCase):
     def test_parameters_file(self, execute_patch):
         self.runner.invoke(
             papermill,
-            self.default_args
-            + ['-f', self.sample_yaml_file, '--parameters_file', self.sample_json_file],
+            self.default_args + [
+                '-f', self.sample_yaml_file, '--parameters_file', self.sample_json_file
+            ],
         )
         execute_patch.assert_called_with(
             **self.augment_execute_kwargs(
@@ -193,8 +194,7 @@ class TestCLI(unittest.TestCase):
     def test_parameters_base64(self, execute_patch):
         self.runner.invoke(
             papermill,
-            self.default_args
-            + [
+            self.default_args + [
                 '--parameters_base64',
                 'eyJmb28iOiAicmVwbGFjZWQiLCAiYmFyIjogMn0=',
                 '-b',
@@ -331,11 +331,18 @@ class TestCLI(unittest.TestCase):
         execute_patch.assert_not_called()
 
     @patch(cli.__name__ + '.execute_notebook')
+    @patch(cli.__name__ + '.display_notebook_help')
+    def test_help_notebook(self, display_notebook_help, execute_path):
+        self.runner.invoke(papermill, ['--help-notebook', 'input_path.ipynb'])
+        execute_path.assert_not_called()
+        assert display_notebook_help.call_count == 1
+        assert display_notebook_help.call_args[0][1] == 'input_path.ipynb'
+
+    @patch(cli.__name__ + '.execute_notebook')
     def test_many_args(self, execute_patch):
         self.runner.invoke(
             papermill,
-            self.default_args
-            + [
+            self.default_args + [
                 '-f',
                 self.sample_yaml_file,
                 '-y',

--- a/papermill/tests/test_cli.py
+++ b/papermill/tests/test_cli.py
@@ -3,8 +3,10 @@
 """ Test the command line interface """
 
 import os
+from pathlib import Path
 import sys
 import subprocess
+import tempfile
 import uuid
 import nbclient
 
@@ -166,6 +168,31 @@ class TestCLI(unittest.TestCase):
         execute_patch.assert_called_with(
             **self.augment_execute_kwargs(parameters={'a_date': '2019-01-01'})
         )
+
+    @patch(cli.__name__ + '.execute_notebook')
+    def test_parameters_empty(self, execute_patch):
+        # "#empty" ---base64--> "I2VtcHR5"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_yaml = Path(tmpdir) / 'empty.yaml'
+            empty_yaml.write_text('#empty')
+            self.runner.invoke(
+                papermill,
+                self.default_args
+                + [
+                    '--parameters_file',
+                    str(empty_yaml),
+                    '--parameters_yaml',
+                    '#empty',
+                    '--parameters_base64',
+                    'I2VtcHR5',
+                ],
+            )
+            execute_patch.assert_called_with(
+                **self.augment_execute_kwargs(
+                    # should be empty
+                    parameters={}
+                )
+            )
 
     @patch(cli.__name__ + '.execute_notebook')
     def test_parameters_yaml_override(self, execute_patch):

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -7,6 +7,8 @@ import unittest
 from functools import partial
 from pathlib import Path
 
+from nbformat import validate
+
 try:
     from unittest.mock import patch
 except ImportError:
@@ -355,3 +357,18 @@ class TestSysExit(unittest.TestCase):
         self.assertEqual(nb.cells[1].outputs[0].ename, 'SystemExit')
         self.assertEqual(nb.cells[1].outputs[0].evalue, '')
         self.assertEqual(nb.cells[2].execution_count, None)
+
+
+class TestNotebookValidation(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_from_version_4_4_upgrades(self):
+        notebook_name = 'nb_version_4.4.ipynb'
+        result_path = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
+        execute_notebook(get_notebook_path(notebook_name), result_path, {'var': 'It works'})
+        nb = load_notebook_node(result_path)
+        validate(nb)

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -331,3 +331,16 @@ class TestSysExit(unittest.TestCase):
         self.assertEqual(nb.cells[3].outputs[0].output_type, 'error')
 
         self.assertEqual(nb.cells[4].execution_count, None)
+
+    def test_system_exit(self):
+        notebook_name = 'systemexit.ipynb'
+        result_path = os.path.join(self.test_dir, 'output_{}'.format(notebook_name))
+        execute_notebook(get_notebook_path(notebook_name), result_path)
+        nb = load_notebook_node(result_path)
+        self.assertEqual(nb.cells[0].cell_type, "code")
+        self.assertEqual(nb.cells[0].execution_count, 1)
+        self.assertEqual(nb.cells[1].execution_count, 2)
+        self.assertEqual(nb.cells[1].outputs[0].output_type, 'error')
+        self.assertEqual(nb.cells[1].outputs[0].ename, 'SystemExit')
+        self.assertEqual(nb.cells[1].outputs[0].evalue, '')
+        self.assertEqual(nb.cells[2].execution_count, None)

--- a/papermill/tests/test_execute.py
+++ b/papermill/tests/test_execute.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 
 from functools import partial
+from pathlib import Path
 
 try:
     from unittest.mock import patch
@@ -277,6 +278,16 @@ class TestCWD(unittest.TestCase):
         self.assertTrue(
             os.path.isfile(os.path.join(self.base_test_dir, self.nb_test_executed_fname))
         )
+
+    def test_pathlib_paths(self):
+        # Copy of test_execution_respects_cwd_assignment but with `Path`s
+        with chdir(self.base_test_dir):
+            execute_notebook(
+                Path(self.check_notebook_name),
+                Path(self.nb_test_executed_fname),
+                cwd=Path(self.test_dir),
+            )
+        self.assertTrue(Path(self.base_test_dir).joinpath(self.nb_test_executed_fname).exists())
 
 
 class TestSysExit(unittest.TestCase):

--- a/papermill/tests/test_inspect.py
+++ b/papermill/tests/test_inspect.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click import Context
+
+from papermill.inspection import display_notebook_help, inspect_notebook
+
+
+NOTEBOOKS_PATH = Path(__file__).parent / "notebooks"
+
+
+def _get_fullpath(name):
+    return NOTEBOOKS_PATH / name
+
+
+@pytest.fixture
+def click_context():
+    mock = MagicMock(spec=Context, command=MagicMock())
+    mock.command.get_usage.return_value = "Dummy usage"
+    return mock
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        (_get_fullpath("no_parameters.ipynb"), {}),
+        (
+            _get_fullpath("simple_execute.ipynb"),
+            {"msg": {"name": "msg", "inferred_type_name": "None", "default": "None", "help": ""}},
+        ),
+        (
+            _get_fullpath("complex_parameters.ipynb"),
+            {
+                "msg": {"name": "msg", "inferred_type_name": "None", "default": "None", "help": ""},
+                "a": {
+                    "name": "a",
+                    "inferred_type_name": "float",
+                    "default": "2.25",
+                    "help": "Variable a",
+                },
+                "b": {
+                    "name": "b",
+                    "inferred_type_name": "List[str]",
+                    "default": "['Hello','World']",
+                    "help": "Nice list",
+                },
+                "c": {"name": "c", "inferred_type_name": "NoneType", "default": "None", "help": ""},
+            },
+        ),
+        (_get_fullpath("notimplemented_translator.ipynb"), {}),
+    ],
+)
+def test_inspect_notebook(name, expected):
+    assert inspect_notebook(str(name)) == expected
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        (
+            _get_fullpath("no_parameters.ipynb"),
+            [
+                "Dummy usage",
+                "\nParameters inferred for notebook '{name}':",
+                "\n  No cell tagged 'parameters'",
+            ],
+        ),
+        (
+            _get_fullpath("simple_execute.ipynb"),
+            [
+                "Dummy usage",
+                "\nParameters inferred for notebook '{name}':",
+                "  msg: Unknown type (default None)",
+            ],
+        ),
+        (
+            _get_fullpath("complex_parameters.ipynb"),
+            [
+                "Dummy usage",
+                "\nParameters inferred for notebook '{name}':",
+                "  msg: Unknown type (default None)",
+                "  a: float (default 2.25)         Variable a",
+                "  b: List[str] (default ['Hello','World'])\n                                  Nice list",  # noqa
+                "  c: NoneType (default None)      ",
+            ],
+        ),
+        (
+            _get_fullpath("notimplemented_translator.ipynb"),
+            [
+                "Dummy usage",
+                "\nParameters inferred for notebook '{name}':",
+                "\n  Can't infer anything about this notebook's parameters. It may not have any parameter defined.",  # noqa
+            ],
+        ),
+    ],
+)
+def test_display_notebook_help(click_context, name, expected):
+    with patch("papermill.inspection.click.echo") as echo:
+        display_notebook_help(click_context, str(name), None)
+
+        assert echo.call_count == len(expected)
+        for call, target in zip(echo.call_args_list, expected):
+            assert call[0][0] == target.format(name=str(name))

--- a/papermill/tests/test_inspect.py
+++ b/papermill/tests/test_inspect.py
@@ -52,7 +52,12 @@ def click_context():
     ],
 )
 def test_inspect_notebook(name, expected):
-    assert inspect_notebook(str(name)) == expected
+    assert inspect_notebook(name) == expected
+
+
+def test_str_path():
+    expected = {"msg": {"name": "msg", "inferred_type_name": "None", "default": "None", "help": ""}}
+    assert inspect_notebook(str(_get_fullpath("simple_execute.ipynb"))) == expected
 
 
 @pytest.mark.parametrize(

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -3,8 +3,11 @@ import pytest
 from unittest.mock import Mock
 from collections import OrderedDict
 
+from nbformat.v4 import new_code_cell
+
 from .. import translators
 from ..exceptions import PapermillException
+from ..models import Parameter
 
 
 @pytest.mark.parametrize(
@@ -61,6 +64,54 @@ def test_translate_codify_python(parameters, expected):
 )
 def test_translate_comment_python(test_input, expected):
     assert translators.PythonTranslator.comment(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("a = 2", [Parameter("a", "None", "2", "")]),
+        ("a: int = 2", [Parameter("a", "int", "2", "")]),
+        ("a = 2 # type:int", [Parameter("a", "int", "2", "")]),
+        ("a = False # Nice variable a", [Parameter("a", "None", "False", "Nice variable a")]),
+        ("a: float = 2.258 # type: int Nice variable a", [Parameter("a", "float", "2.258", "Nice variable a")]),  # noqa
+        (
+            "a = 'this is a string' # type: int Nice variable a",
+            [Parameter("a", "int", "'this is a string'", "Nice variable a")]
+        ),
+        (
+            "a: List[str] = ['this', 'is', 'a', 'string', 'list'] # Nice variable a",
+            [Parameter("a", "List[str]", "['this', 'is', 'a', 'string', 'list']", "Nice variable a")]
+        ),
+        (
+            "a: List[str] = [\n    'this', # First\n    'is',\n    'a',\n    'string',\n    'list' # Last\n] # Nice variable a",  # noqa
+            [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]
+        ),
+        (
+            "a: List[str] = [\n    'this',\n    'is',\n    'a',\n    'string',\n    'list'\n] # Nice variable a",  # noqa
+            [Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a")]
+        ),
+        (
+            """a: List[str] = [
+                'this', # First
+                'is',
+
+                'a',
+                'string',
+                'list' # Last
+            ] # Nice variable a
+
+            b: float = -2.3432 # My b variable
+            """,
+            [
+                Parameter("a", "List[str]", "['this','is','a','string','list']", "Nice variable a"),
+                Parameter("b", "float", "-2.3432", "My b variable"),
+            ]
+        ),
+    ]
+)
+def test_inspect_python(test_input, expected):
+    cell = new_code_cell(source=test_input)
+    assert translators.PythonTranslator.inspect(cell) == expected
 
 
 @pytest.mark.parametrize(

--- a/papermill/tests/test_translators.py
+++ b/papermill/tests/test_translators.py
@@ -245,6 +245,71 @@ def test_translate_codify_csharp(parameters, expected):
     assert translators.CSharpTranslator.codify(parameters) == expected
 
 
+# Powershell section
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        ("foo", '"foo"'),
+        ('{"foo": "bar"}', '"{`"foo`": `"bar`"}"'),
+        ({"foo": "bar"}, '@{"foo" = "bar"}'),
+        ({"foo": '"bar"'}, '@{"foo" = "`"bar`""}'),
+        ({"foo": ["bar"]}, '@{"foo" = @("bar")}'),
+        ({"foo": {"bar": "baz"}}, '@{"foo" = @{"bar" = "baz"}}'),
+        ({"foo": {"bar": '"baz"'}}, '@{"foo" = @{"bar" = "`"baz`""}}'),
+        (["foo"], '@("foo")'),
+        (["foo", '"bar"'], '@("foo", "`"bar`"")'),
+        ([{"foo": "bar"}], '@(@{"foo" = "bar"})'),
+        ([{"foo": '"bar"'}], '@(@{"foo" = "`"bar`""})'),
+        (12345, '12345'),
+        (-54321, '-54321'),
+        (1.2345, '1.2345'),
+        (-5432.1, '-5432.1'),
+        (float('nan'), "[double]::NaN"),
+        (float('-inf'), "[double]::NegativeInfinity"),
+        (float('inf'), "[double]::PositiveInfinity"),
+        (True, '$True'),
+        (False, '$False'),
+        (None, '$Null'),
+    ],
+)
+def test_translate_type_powershell(test_input, expected):
+    assert translators.PowershellTranslator.translate(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "parameters,expected",
+    [
+        ({"foo": "bar"}, '# Parameters\n$foo = "bar"\n'),
+        ({"foo": True}, '# Parameters\n$foo = $True\n'),
+        ({"foo": 5}, '# Parameters\n$foo = 5\n'),
+        ({"foo": 1.1}, '# Parameters\n$foo = 1.1\n'),
+        ({"foo": ['bar', 'baz']}, '# Parameters\n$foo = @("bar", "baz")\n'),
+        ({"foo": {'bar': 'baz'}}, '# Parameters\n$foo = @{"bar" = "baz"}\n'),
+        (
+            OrderedDict([['foo', 'bar'], ['baz', ['buz']]]),
+            '# Parameters\n$foo = "bar"\n$baz = @("buz")\n',
+        ),
+    ],
+)
+def test_translate_codify_powershell(parameters, expected):
+    assert translators.PowershellTranslator.codify(parameters) == expected
+
+
+@pytest.mark.parametrize(
+    "input_name,input_value,expected",
+    [("foo", '""', '$foo = ""'), ("foo", '"bar"', '$foo = "bar"')],
+)
+def test_translate_assign_powershell(input_name, input_value, expected):
+    assert translators.PowershellTranslator.assign(input_name, input_value) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected", [("", '#'), ("foo", '# foo'), ("['best effort']", "# ['best effort']")]
+)
+def test_translate_comment_powershell(test_input, expected):
+    assert translators.PowershellTranslator.comment(test_input) == expected
+
+
 # F# section
 @pytest.mark.parametrize(
     "test_input,expected",

--- a/papermill/tests/test_utils.py
+++ b/papermill/tests/test_utils.py
@@ -5,8 +5,26 @@ import warnings
 from unittest.mock import Mock, call
 from tempfile import TemporaryDirectory
 
-from ..utils import retry, chdir, merge_kwargs, remove_args
+from nbformat.v4 import new_notebook, new_code_cell
+
+from ..utils import (
+    any_tagged_cell,
+    retry,
+    chdir,
+    merge_kwargs,
+    remove_args,
+)
 from ..exceptions import PapermillParameterOverwriteWarning
+
+
+def test_no_tagged_cell():
+    nb = new_notebook(cells=[new_code_cell('a = 2', metadata={"tags": []})],)
+    assert not any_tagged_cell(nb, "parameters")
+
+
+def test_tagged_cell():
+    nb = new_notebook(cells=[new_code_cell('a = 2', metadata={"tags": ["parameters"]})],)
+    assert any_tagged_cell(nb, "parameters")
 
 
 def test_merge_kwargs():

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -548,6 +548,9 @@ papermill_translators.register("matlab", MatlabTranslator)
 papermill_translators.register(".net-csharp", CSharpTranslator)
 papermill_translators.register(".net-fsharp", FSharpTranslator)
 papermill_translators.register(".net-powershell", PowershellTranslator)
+papermill_translators.register("pysparkkernel", PythonTranslator)
+papermill_translators.register("sparkkernel", ScalaTranslator)
+papermill_translators.register("sparkrkernel", RTranslator)
 
 
 def translate_parameters(kernel_name, language, parameters, comment='Parameters'):

--- a/papermill/translators.py
+++ b/papermill/translators.py
@@ -368,6 +368,57 @@ class FSharpTranslator(Translator):
         return 'let {} = {}'.format(name, str_val)
 
 
+class PowershellTranslator(Translator):
+    @classmethod
+    def translate_escaped_str(cls, str_val):
+        """Translate a string to an escaped Matlab string"""
+        if isinstance(str_val, str):
+            str_val = str_val.encode('unicode_escape')
+            if sys.version_info >= (3, 0):
+                str_val = str_val.decode('utf-8')
+            str_val = str_val.replace('"', '`"')
+        return '"{}"'.format(str_val)
+
+    @classmethod
+    def translate_float(cls, val):
+        if math.isfinite(val):
+            return cls.translate_raw_str(val)
+        elif math.isnan(val):
+            return "[double]::NaN"
+        elif val < 0:
+            return "[double]::NegativeInfinity"
+        else:
+            return "[double]::PositiveInfinity"
+
+    @classmethod
+    def translate_none(cls, val):
+        return '$Null'
+
+    @classmethod
+    def translate_bool(cls, val):
+        return '$True' if val else '$False'
+
+    @classmethod
+    def translate_dict(cls, val):
+        kvps = '\n '.join(
+            ["{} = {}".format(cls.translate_str(k), cls.translate(v)) for k, v in val.items()]
+        )
+        return '@{{{}}}'.format(kvps)
+
+    @classmethod
+    def translate_list(cls, val):
+        escaped = ', '.join([cls.translate(v) for v in val])
+        return '@({})'.format(escaped)
+
+    @classmethod
+    def comment(cls, cmt_str):
+        return '# {}'.format(cmt_str).strip()
+
+    @classmethod
+    def assign(cls, name, str_val):
+        return '${} = {}'.format(name, str_val)
+
+
 # Instantiate a PapermillIO instance and register Handlers.
 papermill_translators = PapermillTranslators()
 papermill_translators.register("python", PythonTranslator)
@@ -377,6 +428,7 @@ papermill_translators.register("julia", JuliaTranslator)
 papermill_translators.register("matlab", MatlabTranslator)
 papermill_translators.register(".net-csharp", CSharpTranslator)
 papermill_translators.register(".net-fsharp", FSharpTranslator)
+papermill_translators.register(".net-powershell", PowershellTranslator)
 
 
 def translate_parameters(kernel_name, language, parameters, comment='Parameters'):

--- a/papermill/utils.py
+++ b/papermill/utils.py
@@ -10,6 +10,48 @@ from .exceptions import PapermillParameterOverwriteWarning
 logger = logging.getLogger('papermill.utils')
 
 
+def any_tagged_cell(nb, tag):
+    """Whether the notebook contains at least one cell tagged ``tag``?
+
+    Parameters
+    ----------
+    nb : nbformat.NotebookNode
+        The notebook to introspect
+    tag : str
+        The tag to look for
+
+    Returns
+    -------
+    bool
+        Whether the notebook contains a cell tagged ``tag``?
+    """
+    return any([tag in cell.metadata.tags for cell in nb.cells])
+
+
+def find_first_tagged_cell_index(nb, tag):
+    """Find the first tagged cell ``tag`` in the notebook.
+
+    Parameters
+    ----------
+    nb : nbformat.NotebookNode
+        The notebook to introspect
+    tag : str
+        The tag to look for
+
+    Returns
+    -------
+    nbformat.NotebookNode
+        Whether the notebook contains a cell tagged ``tag``?
+    """
+    parameters_indices = []
+    for idx, cell in enumerate(nb.cells):
+        if tag in cell.metadata.tags:
+            parameters_indices.append(idx)
+    if not parameters_indices:
+        return -1
+    return parameters_indices[0]
+
+
 def merge_kwargs(caller_args, **callee_args):
     """Merge named argument.
 

--- a/papermill/version.py
+++ b/papermill/version.py
@@ -1,1 +1,1 @@
-version = '2.3.0'
+version = '2.3.1'

--- a/papermill/version.py
+++ b/papermill/version.py
@@ -1,1 +1,1 @@
-version = '2.2.0'
+version = '2.2.1'

--- a/papermill/version.py
+++ b/papermill/version.py
@@ -1,1 +1,1 @@
-version = '2.2.1'
+version = '2.2.2'

--- a/papermill/version.py
+++ b/papermill/version.py
@@ -1,1 +1,1 @@
-version = '2.1.3'
+version = '2.2.0'

--- a/papermill/version.py
+++ b/papermill/version.py
@@ -1,1 +1,1 @@
-version = '2.2.2'
+version = '2.3.0'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,19 +1,21 @@
+boto3
+botocore
 codecov
 coverage
+google_compute_engine # Need this because boto has issues with dynamic package loading during tests if other google components are there
+ipython>=5.0
+ipywidgets
 notebook
 mock
+moto
 pytest>=4.1
 pytest-cov>=2.6.1
 pytest-mock>=1.10
 pytest-env>=0.6.2
-ipython>=5.0
-moto
+requests >= 2.21.0
 check-manifest
 attrs>=17.4.0
 pre-commit
-boto3
-botocore
-ipywidgets
 flake8
 tox
 bumpversion
@@ -22,4 +24,3 @@ pip>=18.1
 wheel>=0.31.0
 setuptools>=38.6.0
 twine>=1.11.0
-google_compute_engine # Need this because boto has issues with dynamic package loading during tests if other google components are there

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ansiwrap
 click
 pyyaml
-nbformat
+nbformat >= 5.1.2
 nbclient >= 0.2.0
 tqdm >= 4.32.2
 requests

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ basepython =
     flake8: python3.8
     manifest: python3.8
     dist: python3.8
-    docs: python3.8
+    docs: python3
     binder: python3.8
 deps = .[dev]
 commands = pytest -v --maxfail=2 --cov=papermill -W always {posargs}


### PR DESCRIPTION
Upgrades papermill to 2.3.1

This contains a fix to an issue introduced in a change to nbformat ([see this papermill issue](https://github.com/nteract/papermill/issues/568)) that will raise an error like:
```
Notebook JSON is invalid: Additional properties are not allowed ('id' was unexpected)
```

I'm not sure if this was manifested due to this recent nbformat version bump: https://github.com/viaduct-ai/vml-py/pull/355